### PR TITLE
Reorganize frontend models into new model directory

### DIFF
--- a/frontend/src/api/game.ts
+++ b/frontend/src/api/game.ts
@@ -1,6 +1,6 @@
 import stompClient from '@/api/websocket/stompClient';
 import { toJson } from '@/api/websocket/helpers';
-import { Move } from '@/store/modules/game/moves';
+import { Move } from '@/model/game/moves';
 
 export const errorObservable = () => stompClient.watch(`/user/queue/game/errors`).pipe(toJson);
 

--- a/frontend/src/model/game/card.ts
+++ b/frontend/src/model/game/card.ts
@@ -6,6 +6,10 @@ export enum Color {
     Red = 'red',
 }
 
+export function getColorEnumValues(): Color[] {
+    return Object.keys(Color).map(key => Color[key]);
+}
+
 export class Card {
     value: number = 0;
     color: Color = Color.White;

--- a/frontend/src/model/game/card.ts
+++ b/frontend/src/model/game/card.ts
@@ -29,13 +29,7 @@ export class Card {
 export type Discard = {
     [color: string]: Card[];
 };
+
 export type CardsInPlay = {
     [color: string]: Card[];
 };
-
-export interface GameData {
-    id: number;
-    discard: Discard;
-    player1: any;
-    player2: any;
-}

--- a/frontend/src/model/game/index.ts
+++ b/frontend/src/model/game/index.ts
@@ -1,0 +1,8 @@
+import { Discard } from './card';
+
+export class GameState {
+    id: number | null = null;
+    discard: Discard | null = null;
+    player1: any = null;
+    player2: any = null;
+}

--- a/frontend/src/model/game/moves.ts
+++ b/frontend/src/model/game/moves.ts
@@ -1,4 +1,4 @@
-import { Card, Color } from '@/store/modules/game/model';
+import { Card, Color } from '@/model/game/card';
 
 enum MoveType {
     PlayCard,

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -9,7 +9,6 @@ import './modules/alert';
 import { AuthState } from './modules/auth';
 import { AccountState } from './modules/account';
 import { AlertState } from './modules/alert';
-import { GameStoreState } from '@/store/modules/game';
 
 Vue.use(Vuex);
 
@@ -17,7 +16,6 @@ export interface RootState {
     account: AccountState;
     auth: AuthState;
     alert: AlertState;
-    game: GameStoreState;
 }
 
 const buildStore = () => getStoreBuilder<RootState>().vuexStore();

--- a/frontend/src/store/modules/game/index.ts
+++ b/frontend/src/store/modules/game/index.ts
@@ -1,7 +1,0 @@
-import * as model from './model';
-import * as moves from './moves';
-
-export default {
-    model,
-    moves,
-};

--- a/frontend/src/store/modules/games.ts
+++ b/frontend/src/store/modules/games.ts
@@ -1,1 +1,0 @@
-export default {};

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,5 +1,0 @@
-import { Color } from '@/model/game/card';
-
-export function getColorEnumValues(): Color[] {
-    return Object.keys(Color).map(key => Color[key]);
-}

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,4 +1,4 @@
-import { Color } from '@/store/modules/game/model';
+import { Color } from '@/model/game/card';
 
 export function getColorEnumValues(): Color[] {
     return Object.keys(Color).map(key => Color[key]);

--- a/frontend/src/views/game/Board.vue
+++ b/frontend/src/views/game/Board.vue
@@ -1,8 +1,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
-import { Card, Color, Discard } from '@/model/game/card';
-import { getColorEnumValues } from '@/utils';
+import { Card, Color, Discard, getColorEnumValues } from '@/model/game/card';
 import CardView from '@/views/game/CardView.vue';
 
 @Component({

--- a/frontend/src/views/game/Board.vue
+++ b/frontend/src/views/game/Board.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
-import { Card, Color, Discard } from '@/store/modules/game/model';
+import { Card, Color, Discard } from '@/model/game/card';
 import { getColorEnumValues } from '@/utils';
 import CardView from '@/views/game/CardView.vue';
 

--- a/frontend/src/views/game/CardView.vue
+++ b/frontend/src/views/game/CardView.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
-import { Card } from '@/store/modules/game/model';
+import { Card } from '@/model/game/card';
 
 @Component
 export default class CardView extends Vue {

--- a/frontend/src/views/game/CardsInPlayView.vue
+++ b/frontend/src/views/game/CardsInPlayView.vue
@@ -1,9 +1,8 @@
 <script lang="ts">
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
-import { Card, Color } from '@/model/game/card';
+import { Card, Color, getColorEnumValues } from '@/model/game/card';
 import CardView from '@/views/game/CardView.vue';
-import { getColorEnumValues } from '@/utils';
 
 @Component({
     components: { CardView },

--- a/frontend/src/views/game/CardsInPlayView.vue
+++ b/frontend/src/views/game/CardsInPlayView.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
-import { Card, Color } from '@/store/modules/game/model';
+import { Card, Color } from '@/model/game/card';
 import CardView from '@/views/game/CardView.vue';
 import { getColorEnumValues } from '@/utils';
 

--- a/frontend/src/views/game/GamePlay.vue
+++ b/frontend/src/views/game/GamePlay.vue
@@ -5,7 +5,8 @@ import Board from '@/views/game/Board.vue';
 import CardsInPlayView from '@/views/game/CardsInPlayView.vue';
 import Deck from '@/views/game/Deck.vue';
 import Hand from '@/views/game/Hand.vue';
-import { Card, CardsInPlay, Color, Discard, GameData } from '@/store/modules/game/model';
+import { Card, CardsInPlay, Color, Discard } from '@/model/game/card';
+import { GameState } from '@/model/game';
 import * as gameApi from '@/api/game';
 import { Subscription } from 'rxjs';
 
@@ -15,7 +16,7 @@ import { Subscription } from 'rxjs';
 export default class GamePlay extends Vue {
     deckNumCards: number = 10;
     alwaysShowHand: boolean = true;
-    gameState?: GameData;
+    gameState?: GameState;
     error: string | null = null;
     subscriptions: Subscription[] = [];
 
@@ -33,7 +34,7 @@ export default class GamePlay extends Vue {
     }
 
     private setupSubscriptions() {
-        const setGameState = gameState => {
+        const setGameState = (gameState: GameState) => {
             console.log('Received Game State: ', gameState);
             this.gameState = gameState;
         };

--- a/frontend/src/views/game/Hand.vue
+++ b/frontend/src/views/game/Hand.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
-import { Card } from '@/store/modules/game/model';
+import { Card } from '@/model/game/card';
 import CardView from '@/views/game/CardView.vue';
 
 @Component({


### PR DESCRIPTION
These classes/interfaces were in src/store but that no longer makes sense, as all game state is now being stored on GamePlay (page component) instead of in vuex store. Moved them all to new directory src/model/game. Also moved the getColorEnumValues util function next to the Color enum.